### PR TITLE
Jv cat12vbm long

### DIFF
--- a/brainprep/utils.py
+++ b/brainprep/utils.py
@@ -100,7 +100,8 @@ def check_version(package_name, check_pkg_version):
     print("{0} - {1}".format(package_name, version))
 
 
-def write_matlabbatch(template, nii_files, tpm_file, darteltpm_file, outfile):
+def write_matlabbatch(template, nii_files, tpm_file, darteltpm_file, outfile,
+                      longitudinal=False):
     """ Complete matlab batch from template.
 
     Parameters
@@ -119,8 +120,14 @@ def write_matlabbatch(template, nii_files, tpm_file, darteltpm_file, outfile):
     """
     nii_files_str = ""
     for path in nii_files:
-        nii_files_str += "'{0}' \n".format(
-            ungzip_file(path, outdir=os.path.dirname(outfile)))
+        if longitudinal:
+            ses = path.split(os.sep)[-3]
+            outdir = os.path.join(os.path.dirname(outfile), ses, "anat")
+            nii_files_str += "'{0}' \n".format(
+                ungzip_file(path, outdir=outdir))
+        else:
+            nii_files_str += "'{0}' \n".format(
+                ungzip_file(path, outdir=os.path.dirname(outfile)))
     with open(template, "r") as of:
         stream = of.read()
     stream = stream.format(anat_file=nii_files_str, tpm_file=tpm_file,

--- a/brainprep/workflow/cat12vbm.py
+++ b/brainprep/workflow/cat12vbm.py
@@ -62,9 +62,7 @@ def brainprep_cat12vbm(
     """
     print_title("Complete matlab batch...")
     if not isinstance(anatomical, list):
-        print(anatomical)
         anatomical = anatomical.split(",")
-        print(anatomical)
     resource_dir = os.path.join(
         os.path.dirname(brainprep.__file__), "resources")
     batch_file = os.path.join(outdir, "cat12vbm_matlabbatch.m")

--- a/brainprep/workflow/cat12vbm.py
+++ b/brainprep/workflow/cat12vbm.py
@@ -62,18 +62,24 @@ def brainprep_cat12vbm(
     """
     print_title("Complete matlab batch...")
     if not isinstance(anatomical, list):
+        print(anatomical)
         anatomical = anatomical.split(",")
+        print(anatomical)
     resource_dir = os.path.join(
         os.path.dirname(brainprep.__file__), "resources")
     batch_file = os.path.join(outdir, "cat12vbm_matlabbatch.m")
     if not longitudinal:
         template_batch = os.path.join(resource_dir, "cat12vbm_matlabbatch.m")
+        print("use matlab batch:", template_batch)
+        brainprep.write_matlabbatch(
+            template_batch, anatomical, tpm, darteltpm, batch_file)
     else:
         template_batch = os.path.join(
             resource_dir, "cat12vbm_matlabbatch_longitudinal.m")
-    print("use matlab batch:", template_batch)
-    brainprep.write_matlabbatch(
-        template_batch, anatomical, tpm, darteltpm, batch_file)
+        print("use matlab batch:", template_batch)
+        brainprep.write_matlabbatch(
+            template_batch, anatomical, tpm, darteltpm, batch_file,
+            longitudinal=True)
 
     print_title("Launch CAT12 VBM matlab batch...")
     cmd = [cat12, "-s", spm12, "-m", matlab, "-b", batch_file]


### PR DESCRIPTION
Update cat12vbm longitudinal option to have a written matlabbatch in the sub directory (derivatives/cat12vbm/sub-*/...), and to have the written preprocessing outputs in the ses directory (derivatives/cat12vbm/sub-*/ses-*/...)