### PR TITLE
brainprep/interfaces/utils: Correct error when calling sed

### DIFF
--- a/brainprep/interfaces/utils.py
+++ b/brainprep/interfaces/utils.py
@@ -398,7 +398,7 @@ def anonfile(
     for old, new in mapping.items():
         old_esc = old.replace("/", r"\/")
         new_esc = new.replace("/", r"\/")
-        patterns.extend(["-e", f"'s/{old_esc}/{new_esc}/g'"])
+        patterns.extend(["-e", f"s/{old_esc}/{new_esc}/g"])
     command = [
         "sed",
         *patterns,


### PR DESCRIPTION
It seems sed doesn't like the starting ' when runnin with subprocess. It crashes with the following error message: 
`sed: -e expression #1, char 1: unknown command: `''`